### PR TITLE
Reinstate the "created at" and "updated at" properties in the database

### DIFF
--- a/notion-github-sync.py
+++ b/notion-github-sync.py
@@ -23,6 +23,14 @@ def create_page_metadata(item):
             ]
         },
         "URL": {"type": "url", "url": item["link"]},
+        "Created at": {
+            "type": "date",
+            "date": {"start": item["created_at"].isoformat()},
+        },
+        "Updated at": {
+            "type": "date",
+            "date": {"start": item["updated_at"].isoformat()},
+        },
     }
 
     # Handle the `filter` property


### PR DESCRIPTION
This allows us to sort by most recent activity and stale issues should float to the bottom of the table